### PR TITLE
Item Destroy Development 1

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,12 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
   
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,7 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
+    redirect_to root_path unless item.user_id == current_user.id
     item.destroy
     redirect_to root_path
   end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -79,8 +79,8 @@
             発送までの日数
             <span class="indispensable">必須</span>
           </div>
-          
-        </div><%= f.collection_select(:shipping_time_id, ShippingTime.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+          <%= f.collection_select(:shipping_time_id, ShippingTime.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
       </div>
       <%# /配送について %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     <% if user_signed_in? && (@item.user.id == current_user.id) %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? && (@item.user.id != current_user.id) %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "items#index"
-  resources :items, only: [:new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# what
商品削除機能

# why
出品者が、一度出品した商品を削除できるようにするため。

# 添付動画
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/72d34c605b44c3ebd66617348cdfbaa2